### PR TITLE
Add types for package AOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1183,6 +1183,12 @@
       "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-9.4.1.tgz",
       "integrity": "sha512-oN+htA/GmBNx+aAsCOTElTuCPad9ETPSg/G/B7xM1sI+7VoPqhXJ2P3Feoup3J5Rpw6TF1vUHSzlpELDu6/law=="
     },
+    "@types/aos": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/aos/-/aos-3.0.3.tgz",
+      "integrity": "sha512-H9YIQ8vcCv1F68vdxrZzKsyI5I82FfqJ/D+RTwehau/+FmfpPALtWTBM8OqbnLied4I6yd0f6bbIj3/EtEAHaA==",
+      "dev": true
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "redux-thunk": "^2.3.0"
   },
   "devDependencies": {
+    "@types/aos": "^3.0.3",
     "@types/node": "^13.13.5",
     "@types/react": "^16.9.34",
     "@types/react-redux": "^7.1.9",


### PR DESCRIPTION
This PR adds missing types for the AOS package from `@types/aos`.