### PR TITLE
Add color palette for tsfresh main color

### DIFF
--- a/src/components/content/index.tsx
+++ b/src/components/content/index.tsx
@@ -4,7 +4,7 @@ export default function Content() {
       <section className="bg-gray-100 border-b py-8">
         <div className="container max-w-5xl mx-auto m-8">
           <h2 className="w-full my-2 text-5xl font-black leading-tight text-center text-gray-800">
-            Extract <span className="text-tsfresh-green">Relevant</span>{" "}
+            Extract <span className="text-tsfresh-green-500">Relevant</span>{" "}
             Features Automatically
           </h2>
           <div className="w-full mb-4">

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -9,7 +9,7 @@ export default function Footer() {
                 <span className="text-black font-bold text-2xl lg:text-4xl">
                   ts
                 </span>
-                <span className="text-tsfresh-green font-bold text-2xl lg:text-4xl">
+                <span className="text-tsfresh-green-500 font-bold text-2xl lg:text-4xl">
                   fresh
                 </span>
               </a>

--- a/src/components/hero/index.tsx
+++ b/src/components/hero/index.tsx
@@ -45,7 +45,7 @@ export default function Hero() {
               </span>
               <br />
             </p>
-            {/* <button className="mr-10 mb-10 float-right bg-tsfresh-green hover:bg-green-700 text-white font-bold py-2 px-4 rounded">
+            {/* <button className="mr-10 mb-10 float-right bg-tsfresh-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded">
               Test with your own data
             </button> */}
           </div>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -7,7 +7,7 @@ body {
 }
 
 .gradient {
-  background-image: linear-gradient(-225deg, #a5b69f 0%, theme('colors.tsfresh-green-500') 100%);
+  background-image: linear-gradient(-225deg, #a5b69f 0%, theme('colors.tsfresh-green.500') 100%);
 }
 
 .browser-mockup {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -7,7 +7,7 @@ body {
 }
 
 .gradient {
-  background-image: linear-gradient(-225deg, #a5b69f 0%, #51b63c 100%);
+  background-image: linear-gradient(-225deg, #a5b69f 0%, theme('colors.tsfresh-green-500') 100%);
 }
 
 .browser-mockup {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,15 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        'tsfresh-green': '#51b63c',
+        'tsfresh-green-100': '#E9FBD9',
+        'tsfresh-green-200': '#CFF7B5',
+        'tsfresh-green-300': '#A9E98B',
+        'tsfresh-green-400': '#83D369',
+        'tsfresh-green-500': '#51B63C',
+        'tsfresh-green-600': '#369C2B',
+        'tsfresh-green-700': '#20831E',
+        'tsfresh-green-800': '#136918',
+        'tsfresh-green-900': '#0B5715',
       }
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,15 +3,17 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        'tsfresh-green-100': '#E9FBD9',
-        'tsfresh-green-200': '#CFF7B5',
-        'tsfresh-green-300': '#A9E98B',
-        'tsfresh-green-400': '#83D369',
-        'tsfresh-green-500': '#51B63C',
-        'tsfresh-green-600': '#369C2B',
-        'tsfresh-green-700': '#20831E',
-        'tsfresh-green-800': '#136918',
-        'tsfresh-green-900': '#0B5715',
+        'tsfresh-green': {
+          '100': '#E9FBD9',
+          '200': '#CFF7B5',
+          '300': '#A9E98B',
+          '400': '#83D369',
+          '500': '#51B63C',
+          '600': '#369C2B',
+          '700': '#20831E',
+          '800': '#136918',
+          '900': '#0B5715',
+        }
       }
     },
   },


### PR DESCRIPTION
This PR adds a full color palette for the tsfresh green theme color in order to be compatible with [color definitions in tailwindcss](https://tailwindcss.com/docs/customizing-colors#default-color-palette). The main color becomes `tsfresh-green-500`.
Colors have been auto-generated with the help of [Eva Design System](https://colors.eva.design) and should match closely what tailwind uses, see [this PR](https://github.com/tailwindlabs/tailwindcss/issues/1632) for details.