### PR TITLE
Remove unnecessary css rules

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -2,10 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-  width: 100%;
-}
-
 .gradient {
   background-image: linear-gradient(-225deg, #a5b69f 0%, #51b63c 100%);
 }


### PR DESCRIPTION
This PR removes an unnecessary CSS rule. By default `body` will cover the full page width.